### PR TITLE
fix: ImageAsset subMetas, packed Prefab rehydrate, stable RF UUIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - **Issue #33**: Write meta as `basename+ext+.meta` (e.g. `logo.png.meta`); do not emit orphan `.png.meta` when native PNG was not recovered (2.x SpriteFrame + 3.x pure-native)
 - **Issue #32 / #37**: True 3.x builds emit scenes as `.scene` (+ matching meta); classic 2.4 bundle flavor keeps `.fire`
 - Prefer colocating classic 2.x SpriteFrame meta with the `rawAssets` PNG path
+- **Issue #32**: Fold `Texture2D` / `SpriteFrame` marked `subAsset` into parent `ImageAsset` `.png.meta` `subMetas` (Creator layout) instead of orphan `logo@xxxx` / `spriteFrame.json` folders
+- Strip trailing RootInfo from rehydrated IFileData so Prefab/Scene emit dense `[{__type__:...}]` source JSON; rehydrate packed Prefab pack sections end-to-end
+- Demuxed / copied scripts prefer stable UUID from `cc._RF.push` (decoded) over random meta UUIDs — improves #37 script rebind
 
 ### Features
 - **Issue #23**: Demux packed bundle `index.js` / `game.js` into per-module files under `assets/Scripts` with `.meta` (preserves `cc._RF` UUID mounts); split multi-`System.register` chunks similarly. Raw bundle script still copied for reference; recovered script count includes split modules
@@ -14,6 +17,7 @@
 
 ### Tests
 - Regression fixtures for correct meta names, no orphan meta without PNG, `.scene` for 3.x, `.fire` for 2.4 bundle flavor, and multi-script demux from packed `index.js`
+- ImageAsset subMetas folding, packed Prefab rehydrate, redirect skip count, System.register demux RF UUID stability
 
 ## [2.1.1] - 2026-07-23
 

--- a/__tests__/cocos3x/engine3x.test.js
+++ b/__tests__/cocos3x/engine3x.test.js
@@ -1,7 +1,14 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { reverseProject3x } = require('../../src/core/cocos3x/engine3x');
+const {
+  reverseProject3x,
+  parentPathOfSubAsset,
+  indexImageSubAssets,
+  extractRfUuid,
+} = require('../../src/core/cocos3x/engine3x');
+const { uuidUtils } = require('../../src/utils/uuidUtils');
+const { DataTypeID } = require('../../src/core/cocos3x/rehydrate');
 
 describe('reverseProject3x — end-to-end on a synthetic fixture', () => {
   let tmp;
@@ -258,6 +265,12 @@ cc._RF.pop();
     expect(fs.existsSync(path.join(out, 'assets', 'Scripts', 'scripts', 'Bar.ts'))).toBe(true);
     expect(fs.existsSync(path.join(out, 'assets', 'Scripts', 'scripts', 'Foo.ts.meta'))).toBe(true);
     expect(summary.scripts.total).toBeGreaterThanOrEqual(2);
+
+    // Stable UUID from cc._RF.push (decoded), not a random one.
+    const fooMeta = JSON.parse(
+      fs.readFileSync(path.join(out, 'assets', 'Scripts', 'scripts', 'Foo.ts.meta'), 'utf8'),
+    );
+    expect(fooMeta.uuid).toBe(uuidUtils.decodeUuid('fcmR3XADNLgJ1ByKhqcC5Z'));
   });
 
   it('keeps .fire for 2.4.x-bundle flavor scenes', async () => {
@@ -291,4 +304,251 @@ cc._RF.pop();
     expect(fs.existsSync(path.join(out, 'assets', 'main', 'scenes', 'Main.scene'))).toBe(false);
   });
 
+  it('folds Texture2D/SpriteFrame subAssets into ImageAsset .png.meta subMetas', async () => {
+    const src = path.join(tmp, 'img-sub-build');
+    writeFile(path.join(src, 'application.js'), '// launcher');
+    writeFile(path.join(src, 'src', 'settings.json'), '{}');
+
+    const bundleDir = path.join(src, 'assets', 'main');
+    const config = {
+      name: 'main',
+      debug: true,
+      importBase: 'import',
+      nativeBase: 'native',
+      uuids: ['u-img', 'u-tex', 'u-sf'],
+      paths: {
+        0: ['textures/logo', 0],
+        1: ['textures/logo@6c48a', 1, 1],
+        2: ['textures/logo@f9941', 2, 1],
+      },
+      types: ['cc.ImageAsset', 'cc.Texture2D', 'cc.SpriteFrame'],
+      scenes: {},
+      extensionMap: { '.png': ['u-img'] },
+      versions: { import: [], native: [] },
+    };
+    writeFile(path.join(bundleDir, 'config.json'), JSON.stringify(config));
+    writeFile(
+      path.join(bundleDir, 'import', 'u-', 'u-img.json'),
+      JSON.stringify({ __type__: 'cc.ImageAsset', _name: 'logo' }),
+    );
+    writeFile(
+      path.join(bundleDir, 'import', 'u-', 'u-tex.json'),
+      JSON.stringify({ __type__: 'cc.Texture2D', _name: 'logo' }),
+    );
+    writeFile(
+      path.join(bundleDir, 'import', 'u-', 'u-sf.json'),
+      JSON.stringify({ __type__: 'cc.SpriteFrame', _name: 'logo' }),
+    );
+    writeFile(path.join(bundleDir, 'native', 'u-', 'u-img.png'), 'PNGDATA');
+
+    const out = path.join(tmp, 'out-img-sub');
+    await reverseProject3x({ sourcePath: src, outputPath: out, assetsOnly: true });
+
+    expect(fs.existsSync(path.join(out, 'assets', 'main', 'textures', 'logo.png'))).toBe(true);
+    const metaPath = path.join(out, 'assets', 'main', 'textures', 'logo.png.meta');
+    expect(fs.existsSync(metaPath)).toBe(true);
+    const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+    expect(meta.uuid).toBe('u-img');
+    expect(meta.importer).toBe('image');
+    expect(Object.keys(meta.subMetas).length).toBe(2);
+    const vals = Object.values(meta.subMetas);
+    expect(vals.map((v) => v.displayName).sort()).toEqual(['spriteFrame', 'texture']);
+    expect(vals.find((v) => v.displayName === 'texture').uuid).toBe('u-tex');
+    expect(vals.find((v) => v.displayName === 'spriteFrame').uuid).toBe('u-sf');
+
+    // No orphan subAsset folders / loose spriteFrame.json
+    expect(fs.existsSync(path.join(out, 'assets', 'main', 'textures', 'logo@6c48a'))).toBe(false);
+    expect(fs.existsSync(path.join(out, 'assets', 'main', 'textures', 'logo@f9941'))).toBe(false);
+  });
+
+  it('rehydrates packed Prefab sections to Creator source-shaped JSON', async () => {
+    const src = path.join(tmp, 'packed-prefab-build');
+    writeFile(path.join(src, 'application.js'), '// launcher');
+    writeFile(path.join(src, 'src', 'settings.json'), '{}');
+
+    const bundleDir = path.join(src, 'assets', 'main');
+    const packUuid = 'u-pack01';
+    const prefabUuid = 'u-prefab1';
+    const config = {
+      name: 'main',
+      debug: true,
+      importBase: 'import',
+      nativeBase: 'native',
+      uuids: [prefabUuid, packUuid],
+      paths: {
+        0: ['prefabs/Button', 0],
+      },
+      types: ['cc.Prefab'],
+      scenes: {},
+      packs: {
+        [packUuid]: [0],
+      },
+      extensionMap: {},
+      versions: { import: [], native: [] },
+    };
+    writeFile(path.join(bundleDir, 'config.json'), JSON.stringify(config));
+
+    // IPackedFileData: shared header + one Prefab section (no standalone import).
+    const section = [
+      [
+        [0, 'Button', 1],
+        [1, 'Button', []],
+        0,
+      ],
+      0,
+      null,
+      [],
+      [],
+      [],
+    ];
+    const packDoc = [
+      1,
+      [],
+      [],
+      [
+        ['cc.Prefab', ['_name', 'data'], 2, DataTypeID.InstanceRef],
+        ['cc.Node', ['_name', '_children'], 2, DataTypeID.Array_InstanceRef],
+      ],
+      [
+        [0, 0, 1, 2],
+        [1, 0, 1, 2],
+      ],
+      [section],
+    ];
+    writeFile(
+      path.join(bundleDir, 'import', packUuid.slice(0, 2), `${packUuid}.json`),
+      JSON.stringify(packDoc),
+    );
+
+    const out = path.join(tmp, 'out-packed-prefab');
+    await reverseProject3x({ sourcePath: src, outputPath: out, assetsOnly: true });
+
+    const prefabPath = path.join(out, 'assets', 'main', 'prefabs', 'Button.prefab');
+    expect(fs.existsSync(prefabPath)).toBe(true);
+    const doc = JSON.parse(fs.readFileSync(prefabPath, 'utf8'));
+    expect(Array.isArray(doc)).toBe(true);
+    expect(doc[0].__type__).toBe('cc.Prefab');
+    expect(doc[0].data).toEqual({ __id__: 1 });
+    expect(doc[1].__type__).toBe('cc.Node');
+    expect(doc[1]._name).toBe('Button');
+    expect(typeof doc[doc.length - 1]).not.toBe('number');
+  });
+
+  it('skips redirected uuids owned by dependency bundles', async () => {
+    const src = path.join(tmp, 'redirect-build');
+    writeFile(path.join(src, 'application.js'), '// launcher');
+    writeFile(path.join(src, 'src', 'settings.json'), '{}');
+
+    const bundleDir = path.join(src, 'assets', 'main');
+    const config = {
+      name: 'main',
+      debug: true,
+      importBase: 'import',
+      nativeBase: 'native',
+      deps: ['resources'],
+      uuids: ['u-local', 'u-remote'],
+      paths: {
+        0: ['textures/local', 0],
+        1: ['textures/remote', 0],
+      },
+      types: ['cc.Texture2D'],
+      scenes: {},
+      redirect: [1, 0],
+      extensionMap: { '.png': ['u-local'] },
+      versions: { import: [], native: [] },
+    };
+    writeFile(path.join(bundleDir, 'config.json'), JSON.stringify(config));
+    writeFile(
+      path.join(bundleDir, 'import', 'u-', 'u-local.json'),
+      JSON.stringify({ __type__: 'cc.Texture2D', _name: 'local' }),
+    );
+    writeFile(path.join(bundleDir, 'native', 'u-', 'u-local.png'), 'PNG');
+
+    const out = path.join(tmp, 'out-redirect');
+    const summary = await reverseProject3x({
+      sourcePath: src,
+      outputPath: out,
+      assetsOnly: true,
+    });
+
+    expect(summary.bundles[0].redirected).toBe(1);
+    expect(fs.existsSync(path.join(out, 'assets', 'main', 'textures', 'local.png'))).toBe(true);
+    expect(fs.existsSync(path.join(out, 'assets', 'main', 'textures', 'remote.png'))).toBe(false);
+  });
+
+  it('demuxes multi System.register chunks with stable RF uuids', async () => {
+    const src = path.join(tmp, 'sysreg-build');
+    writeFile(path.join(src, 'application.js'), '// launcher');
+    writeFile(path.join(src, 'src', 'settings.json'), '{}');
+
+    const bundleDir = path.join(src, 'assets', 'main');
+    writeFile(
+      path.join(bundleDir, 'config.json'),
+      JSON.stringify({
+        name: 'main',
+        debug: true,
+        importBase: 'import',
+        nativeBase: 'native',
+        uuids: [],
+        paths: {},
+        types: [],
+        scenes: {},
+        extensionMap: {},
+        versions: { import: [], native: [] },
+      }),
+    );
+
+    const chunk = `
+System.register("chunks:///_virtual/Hero.ts", ["cc"], function (e) {
+  cc._RF.push(module, "fcmR3XADNLgJ1ByKhqcC5Z", "Hero");
+  e("Hero", class Hero {});
+  cc._RF.pop();
+});
+System.register("chunks:///_virtual/Enemy.ts", ["cc"], function (e) {
+  cc._RF.push(module, "68076EFnW1JeZUzdnbOOKNr", "Enemy");
+  e("Enemy", class Enemy {});
+  cc._RF.pop();
+});
+`;
+    writeFile(path.join(src, 'src', 'chunks', 'bundle.js'), chunk);
+
+    const out = path.join(tmp, 'out-sysreg');
+    const summary = await reverseProject3x({ sourcePath: src, outputPath: out });
+
+    expect(summary.scripts.total).toBeGreaterThanOrEqual(2);
+    const heroMetaPath = path.join(out, 'assets', 'Scripts', 'chunks___virtual_Hero.ts.js.meta');
+    // sanitize turns chunks:///_virtual/Hero.ts → chunks___virtual_Hero.ts
+    const scriptsDir = path.join(out, 'assets', 'Scripts');
+    const metas = fs.readdirSync(scriptsDir).filter((f) => f.endsWith('.meta'));
+    expect(metas.length).toBeGreaterThanOrEqual(2);
+    const heroMetaFile = metas.find((f) => /Hero/i.test(f));
+    expect(heroMetaFile).toBeTruthy();
+    const heroMeta = JSON.parse(fs.readFileSync(path.join(scriptsDir, heroMetaFile), 'utf8'));
+    expect(heroMeta.uuid).toBe(uuidUtils.decodeUuid('fcmR3XADNLgJ1ByKhqcC5Z'));
+    expect(extractRfUuid(chunk)).toBe('fcmR3XADNLgJ1ByKhqcC5Z');
+  });
+
+});
+
+describe('image subAsset path helpers', () => {
+  it('parses @id and /texture|/spriteFrame parent paths', () => {
+    expect(parentPathOfSubAsset('textures/logo@6c48a')).toBe('textures/logo');
+    expect(parentPathOfSubAsset('textures/logo/texture')).toBe('textures/logo');
+    expect(parentPathOfSubAsset('textures/logo/spriteFrame')).toBe('textures/logo');
+    expect(parentPathOfSubAsset('textures/logo')).toBeNull();
+  });
+
+  it('indexes subAssets onto parent paths', () => {
+    const cfg = {
+      paths: {
+        'u-img': { path: 'textures/logo', type: 'cc.ImageAsset', subAsset: false },
+        'u-tex': { path: 'textures/logo@6c48a', type: 'cc.Texture2D', subAsset: true },
+        'u-sf': { path: 'textures/logo/spriteFrame', type: 'cc.SpriteFrame', subAsset: true },
+      },
+    };
+    const { byParent, childUuids } = indexImageSubAssets(cfg);
+    expect(childUuids.has('u-tex')).toBe(true);
+    expect(childUuids.has('u-sf')).toBe(true);
+    expect(byParent.get('textures/logo')).toHaveLength(2);
+  });
 });

--- a/__tests__/cocos3x/rehydrate.test.js
+++ b/__tests__/cocos3x/rehydrate.test.js
@@ -244,7 +244,7 @@ describe('rehydrateIFileData', () => {
     expect(out[0].mixed).toEqual([1, { __id__: 1 }, { __id__: 2 }]);
   });
 
-  it('preserves RootInfo tail', () => {
+  it('strips RootInfo tail for editor source shape', () => {
     const doc = build({
       sharedClasses: [['cc.Asset', ['_name'], 0]],
       sharedMasks: [[0, 0, 2]],
@@ -254,8 +254,39 @@ describe('rehydrateIFileData', () => {
       ],
     });
     const out = rehydrateIFileData(doc);
-    // Root info is kept at the end; test that the asset itself is at [0].
+    expect(out).toHaveLength(1);
     expect(out[0]).toEqual({ __type__: 'cc.Asset', _name: 'A' });
+  });
+
+  it('rehydrates a packed-style Prefab section into [{__type__}, ...]', () => {
+    // Mirrors extractPackSection output: shared header + one prefab section.
+    const doc = build({
+      sharedClasses: [
+        ['cc.Prefab', ['_name', 'data'], 2, DataTypeID.InstanceRef],
+        ['cc.Node', ['_name', '_children'], 2, DataTypeID.Array_InstanceRef],
+      ],
+      sharedMasks: [
+        [0, 0, 1, 2],
+        [1, 0, 1, 2],
+      ],
+      instances: [
+        [0, 'Button', 1],
+        [1, 'Button', []],
+        0,
+      ],
+    });
+    const out = rehydrateIFileData(doc);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual({
+      __type__: 'cc.Prefab',
+      _name: 'Button',
+      data: { __id__: 1 },
+    });
+    expect(out[1]).toEqual({
+      __type__: 'cc.Node',
+      _name: 'Button',
+      _children: [],
+    });
   });
 
   it('exposes the value-type constructor list', () => {

--- a/src/core/cocos3x/engine3x.js
+++ b/src/core/cocos3x/engine3x.js
@@ -308,6 +308,12 @@ async function unpackBundle({ bundleDir, outputPath, verbose, flavor, key, warni
   // Remember pack files we've already copied so we only copy once per bundle.
   cfg._copiedPacks = new Set();
 
+  // Index ImageAsset children (Texture2D / SpriteFrame marked subAsset) so we
+  // can fold them into the parent .png.meta subMetas instead of orphan folders.
+  const subIndex = indexImageSubAssets(cfg);
+  cfg._imageSubByParent = subIndex.byParent;
+  cfg._foldedSubUuids = subIndex.childUuids;
+
   const result = {
     name: cfg.name,
     encrypted: cfg.encrypted,
@@ -341,6 +347,11 @@ async function unpackBundle({ bundleDir, outputPath, verbose, flavor, key, warni
   const pathUuids = Object.keys(cfg.paths);
   await forEachPool(pathUuids, concurrency, async (uuid) => {
     if (shouldSkipRedirect(uuid)) return;
+    // Folded into parent ImageAsset .meta — do not emit orphan texture folders.
+    if (cfg._foldedSubUuids && cfg._foldedSubUuids.has(uuid)) {
+      handled.add(uuid);
+      return;
+    }
     const info = cfg.paths[uuid];
     try {
       const ok = await unpackAsset({
@@ -389,6 +400,10 @@ async function unpackBundle({ bundleDir, outputPath, verbose, flavor, key, warni
   const packedJobs = cfg.uuids.filter((uuid) => !handled.has(uuid));
   await forEachPool(packedJobs, concurrency, async (uuid) => {
     if (shouldSkipRedirect(uuid)) return;
+    if (cfg._foldedSubUuids && cfg._foldedSubUuids.has(uuid)) {
+      handled.add(uuid);
+      return;
+    }
     const info = {
       path: `_packed/${uuid.slice(0, 2)}/${uuid}`,
       type: null,
@@ -552,9 +567,93 @@ async function unpackAsset({ cfg, uuid, info, bundleOut, verbose, flavor }) {
     importRecovered,
     nativeExt: recoveredNativeExt,
     nativeRecovered,
+    assetPath: info.path || null,
+    subMetas: buildImageSubMetas(cfg, info),
   });
 
   return importRecovered || nativeRecovered;
+}
+
+
+/**
+ * Map Texture2D / SpriteFrame entries marked `subAsset` onto their parent
+ * ImageAsset (or Texture2D) path. Creator 3.x stores these as:
+ *   textures/logo@6c48a   or   textures/logo/texture|spriteFrame
+ */
+function indexImageSubAssets(cfg) {
+  const byParent = new Map();
+  const childUuids = new Set();
+  const paths = cfg.paths || {};
+  for (const uuid of Object.keys(paths)) {
+    const info = paths[uuid];
+    if (!info || !info.subAsset) continue;
+    const parentPath = parentPathOfSubAsset(info.path);
+    if (!parentPath) continue;
+    const displayName = displayNameOfSubAsset(info.path, info.type);
+    if (!byParent.has(parentPath)) byParent.set(parentPath, []);
+    byParent.get(parentPath).push({
+      uuid,
+      type: info.type,
+      path: info.path,
+      displayName,
+    });
+    childUuids.add(uuid);
+  }
+  return { byParent, childUuids };
+}
+
+function parentPathOfSubAsset(relPath) {
+  if (!relPath || typeof relPath !== 'string') return null;
+  const at = relPath.lastIndexOf('@');
+  if (at > 0) return relPath.slice(0, at);
+  const m = relPath.match(/^(.*)\/(texture|spriteFrame|sprite-frame)$/i);
+  return m ? m[1] : null;
+}
+
+function displayNameOfSubAsset(relPath, type) {
+  if (type === 'cc.Texture2D') return 'texture';
+  if (type === 'cc.SpriteFrame') return 'spriteFrame';
+  if (!relPath) return 'sub';
+  const at = relPath.lastIndexOf('@');
+  if (at > 0) return relPath.slice(at + 1) || 'sub';
+  const base = path.basename(relPath);
+  if (/^sprite-?frame$/i.test(base)) return 'spriteFrame';
+  if (/^texture$/i.test(base)) return 'texture';
+  return base || 'sub';
+}
+
+function shortMetaId(uuid) {
+  const hex = String(uuid || '').replace(/-/g, '');
+  return (hex.slice(0, 5) || '00000').toLowerCase();
+}
+
+/**
+ * Build Creator-layout subMetas for an ImageAsset / texture parent from folded
+ * child uuids. Returns null when nothing to fold.
+ */
+function buildImageSubMetas(cfg, info) {
+  if (!cfg || !info || !info.path) return null;
+  if (!cfg._imageSubByParent) return null;
+  const children = cfg._imageSubByParent.get(info.path);
+  if (!children || children.length === 0) return null;
+
+  const subMetas = {};
+  for (const child of children) {
+    const id = shortMetaId(child.uuid);
+    const name = child.displayName || 'sub';
+    const importer = classToImporter(child.type) || 'asset';
+    subMetas[id] = {
+      ver: '1.0.1',
+      uuid: child.uuid,
+      importer,
+      displayName: name,
+      id,
+      name,
+      userData: {},
+      subMetas: {},
+    };
+  }
+  return subMetas;
 }
 
 function classOutputDir(className) {
@@ -717,6 +816,7 @@ async function writeMeta(outBase, uuid, className, opts = {}) {
     importRecovered = false,
     nativeExt = null,
     nativeRecovered = false,
+    subMetas = null,
   } = opts;
 
   // Decide which file the meta sits beside: basename + ext + '.meta'
@@ -745,7 +845,7 @@ async function writeMeta(outBase, uuid, className, opts = {}) {
     importer: classToImporter(className),
     downloadMode: 0,
     duration: 0,
-    subMetas: {},
+    subMetas: (subMetas && typeof subMetas === 'object') ? subMetas : {},
   };
   if (wasCcon) meta.source = 'ccon';
   if (packRef) {
@@ -878,7 +978,7 @@ async function recoverScripts(sourcePath, outputPath, verbose, extras = {}) {
     }
     await mkdir(path.dirname(dest), { recursive: true });
     await writeFile(dest, code);
-    await writeScriptMeta(dest);
+    await writeScriptMeta(dest, extractRfUuid(code));
     total += 1;
     if (verbose) logger.debug(`Script: ${label}`);
   });
@@ -1173,5 +1273,9 @@ module.exports = {
   writeMeta,
   splitSystemRegisterSource,
   countSystemRegisters,
+  indexImageSubAssets,
+  parentPathOfSubAsset,
+  buildImageSubMetas,
+  extractRfUuid,
 };
 

--- a/src/core/cocos3x/rehydrate.js
+++ b/src/core/cocos3x/rehydrate.js
@@ -118,7 +118,18 @@ function rehydrateIFileData(doc, options = {}) {
     inlineInstanceRefs(ctx);
   }
 
-  return ctx.instances.slice();
+  // Editor source format is a dense object array `[{__type__}, ...]`.
+  // Drop trailing RootInfo integers / sparse holes left by pre-allocation.
+  const out = ctx.instances.slice();
+  while (out.length > 0) {
+    const tail = out[out.length - 1];
+    if (tail === undefined || typeof tail === 'number') {
+      out.pop();
+      continue;
+    }
+    break;
+  }
+  return out;
 }
 
 function isIFileDataTuple(doc) {


### PR DESCRIPTION
Fixes follow-up recovery quality for #32 and #37: fold Texture2D/SpriteFrame subAssets into ImageAsset png.meta subMetas; strip RootInfo so packed Prefabs emit editor-shaped JSON; prefer stable cc._RF.push UUIDs on demuxed scripts; redirect skip regression. Tests: 137 passed (was 130).