### PR TITLE
fix: decode @-suffix uuids + map texture natives to real paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Fixes
+- Decode Creator compressed uuids that carry `@subAsset` / `@mip@format` suffixes so `native/<2>/<decoded>@….png` lookups succeed (was leaving ids compressed when length ≠ 22)
+- Use `@suffix` as ImageAsset `subMetas` id (`6c48a` / `f9941`) so Texture2D + SpriteFrame no longer collide into one meta slot
+- Strip `/texture` / `/spriteFrame` / `@6c48a|@f9941` from output file paths; fold uuid-only `@` siblings onto parent ImageAsset (named path or `_packed/<2>/<base>`)
+- Sweep leftover `native/` files and report per-bundle native image counts (explicit “import descriptors only” note for web-mobile builds with zero image bytes)
 - Normalize `config.paths` `db://` **and** `db:/` (single-slash) prefixes so recovered assets are not written under a literal `db:` directory (real Creator 3.8 web-mobile)
 - Treat Creator 3.x rollup `System.register("chunks:///_virtual/...")` packs as SystemJS (not browserify); demux one file per register id (`Foo.ts`) with aliased `._RF.push` UUID metas — no more bogus `setters.ts`
 - Skip anonymous / variable-id `System.register` wrappers (nested rollup shell + `mid`/`cid` reexports) so recovery no longer emits empty `module_N.js` stubs

--- a/__tests__/cocos3x/bundleConfig.test.js
+++ b/__tests__/cocos3x/bundleConfig.test.js
@@ -197,3 +197,32 @@ describe('parseBundleConfig — real 3.8 db:/ paths', () => {
     expect(cfg.paths['u-scene'].path.includes('db:')).toBe(false);
   });
 });
+
+
+describe('parseBundleConfig — @suffix uuid decode', () => {
+  it('decodes compressed uuids that carry @6c48a / @mip@fmt suffixes', () => {
+    const raw = {
+      name: 'main',
+      debug: false,
+      importBase: 'import',
+      nativeBase: 'native',
+      uuids: [
+        '20g1ukYUVPvKWKBRznAKo+',
+        '20g1ukYUVPvKWKBRznAKo+@6c48a',
+        '6fAc9/gb9Kfr1dCvwZaWSA@b47c0@40c10',
+      ],
+      paths: {},
+      types: [],
+      versions: { import: [], native: [] },
+      extensionMap: {},
+    };
+    const cfg = parseBundleConfig(raw, '/fake/main');
+    expect(cfg.uuids[0]).toBe('20835ba4-6145-4fbc-a58a-051ce700aa3e');
+    expect(cfg.uuids[1]).toBe('20835ba4-6145-4fbc-a58a-051ce700aa3e@6c48a');
+    expect(cfg.uuids[2]).toBe('6f01cf7f-81bf-4a7e-bd5d-0afc19696480@b47c0@40c10');
+    const native = getNativePath(cfg, cfg.uuids[2], '.png');
+    expect(native.replace(/\\/g, '/')).toMatch(
+      /native\/6f\/6f01cf7f-81bf-4a7e-bd5d-0afc19696480@b47c0@40c10\.png$/,
+    );
+  });
+});

--- a/__tests__/cocos3x/engine3x.test.js
+++ b/__tests__/cocos3x/engine3x.test.js
@@ -4,7 +4,9 @@ const path = require('path');
 const {
   reverseProject3x,
   parentPathOfSubAsset,
+  normalizeAssetFilePath,
   indexImageSubAssets,
+  shortMetaId,
   extractRfUuid,
   splitSystemRegisterSource,
   sanitizeScriptFileName,
@@ -676,6 +678,7 @@ describe('image subAsset path helpers', () => {
 
   it('indexes subAssets onto parent paths', () => {
     const cfg = {
+      uuids: ['u-img', 'u-tex', 'u-sf'],
       paths: {
         'u-img': { path: 'textures/logo', type: 'cc.ImageAsset', subAsset: false },
         'u-tex': { path: 'textures/logo@6c48a', type: 'cc.Texture2D', subAsset: true },
@@ -687,4 +690,121 @@ describe('image subAsset path helpers', () => {
     expect(childUuids.has('u-sf')).toBe(true);
     expect(byParent.get('textures/logo')).toHaveLength(2);
   });
+
+  it('strips /texture and @suffix from asset file paths', () => {
+    expect(normalizeAssetFilePath('UI_res/headimage/texture')).toBe('UI_res/headimage');
+    expect(normalizeAssetFilePath('UI_res/headimage/spriteFrame')).toBe('UI_res/headimage');
+    expect(normalizeAssetFilePath('db_stripped/logo@6c48a')).toBe('db_stripped/logo');
+    expect(normalizeAssetFilePath('UI_res/headimage')).toBe('UI_res/headimage');
+  });
+
+  it('uses @suffix as shortMetaId so texture/spriteFrame do not collide', () => {
+    const base = '0732b29a-d743-449d-aae6-331e8bcda30a';
+    expect(shortMetaId(`${base}@6c48a`)).toBe('6c48a');
+    expect(shortMetaId(`${base}@f9941`)).toBe('f9941');
+    expect(shortMetaId('u-tex')).toBe('utex'); // dashes stripped, first 5
+  });
+
+  it('folds uuid-only @6c48a/@f9941 onto _packed parent path', () => {
+    const base = '20835ba4-6145-4fbc-a58a-051ce700aa3e';
+    const cfg = {
+      uuids: [base, `${base}@6c48a`, `${base}@f9941`],
+      paths: {},
+    };
+    const { byParent, childUuids } = indexImageSubAssets(cfg);
+    expect(childUuids.has(`${base}@6c48a`)).toBe(true);
+    expect(childUuids.has(`${base}@f9941`)).toBe(true);
+    const parent = `_packed/${base.slice(0, 2)}/${base}`;
+    expect(byParent.get(parent)).toHaveLength(2);
+  });
 });
+
+describe('reverseProject3x — packed natives with @ uuids', () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-reverse3x-packnat-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function writeFile(p, content) {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, content);
+  }
+
+  it('recovers named ImageAsset + folds @subAssets; maps compressed @ native', async () => {
+    const src = path.join(tmp, 'tex-build');
+    writeFile(path.join(src, 'application.js'), '// launcher');
+    writeFile(path.join(src, 'src', 'settings.json'), '{}');
+
+    // Real-style compressed ids (22-char) + @suffixes, debug:false so decode runs.
+    const imgComp = '07MrKa10NEnarmMx6LzaMK'; // -> 0732b29a-...
+    const texComp = `${imgComp}@6c48a`;
+    const sfComp = `${imgComp}@f9941`;
+    const orphanComp = '6fAc9/gb9Kfr1dCvwZaWSA@b47c0@40c10'; // mip/format native
+
+    const imgUuid = uuidUtils.decodeUuid(imgComp);
+    const orphanUuid = uuidUtils.decodeUuid(orphanComp);
+
+    const bundleDir = path.join(src, 'assets', 'resources');
+    const config = {
+      name: 'resources',
+      debug: false,
+      importBase: 'import',
+      nativeBase: 'native',
+      uuids: [imgComp, texComp, sfComp, orphanComp],
+      paths: {
+        0: ['UI_res/headimage', 0, 1],
+        1: ['UI_res/headimage/texture', 1, 1],
+        2: ['UI_res/headimage/spriteFrame', 2, 1],
+      },
+      types: ['cc.ImageAsset', 'cc.Texture2D', 'cc.SpriteFrame'],
+      scenes: {},
+      packs: {},
+      extensionMap: {},
+      versions: { import: [], native: [] },
+    };
+    writeFile(path.join(bundleDir, 'config.json'), JSON.stringify(config));
+    writeFile(
+      path.join(bundleDir, 'import', imgUuid.slice(0, 2), `${imgUuid}.json`),
+      JSON.stringify([1, 0, 0, ['cc.ImageAsset'], 0, [{ fmt: '0', w: 8, h: 8 }, -1], [0], 0, [], [], []]),
+    );
+    // Named native under decoded uuid
+    writeFile(path.join(bundleDir, 'native', imgUuid.slice(0, 2), `${imgUuid}.png`), 'PNGDATA');
+    // Orphan compressed-format native (no path entry)
+    writeFile(
+      path.join(bundleDir, 'native', orphanUuid.slice(0, 2), `${orphanUuid}.png`),
+      'PNGORPHAN',
+    );
+
+    const out = path.join(tmp, 'out-tex');
+    const summary = await reverseProject3x({ sourcePath: src, outputPath: out, assetsOnly: true });
+
+    // Prefer real name over _packed
+    expect(fs.existsSync(path.join(out, 'assets', 'resources', 'UI_res', 'headimage.png'))).toBe(true);
+    expect(fs.existsSync(path.join(out, 'assets', 'resources', 'UI_res', 'headimage', 'texture.png'))).toBe(false);
+
+    const meta = JSON.parse(
+      fs.readFileSync(path.join(out, 'assets', 'resources', 'UI_res', 'headimage.png.meta'), 'utf8'),
+    );
+    expect(meta.uuid).toBe(imgUuid);
+    expect(Object.keys(meta.subMetas).sort()).toEqual(['6c48a', 'f9941']);
+    expect(meta.subMetas['6c48a'].displayName).toBe('texture');
+    expect(meta.subMetas['f9941'].displayName).toBe('spriteFrame');
+    expect(meta.subMetas['6c48a'].uuid).toBe(uuidUtils.decodeUuid(texComp));
+
+    // Compressed @mip@fmt native recovered (under _packed — no config path)
+    const orphanOut = path.join(
+      out, 'assets', 'resources', '_packed', orphanUuid.slice(0, 2), `${orphanUuid}.png`,
+    );
+    expect(fs.existsSync(orphanOut)).toBe(true);
+    expect(fs.readFileSync(orphanOut, 'utf8')).toBe('PNGORPHAN');
+
+    const resBundle = summary.bundles.find((b) => b.name === 'resources');
+    expect(resBundle.nativeImages).toBeGreaterThanOrEqual(2);
+  });
+});
+

--- a/__tests__/uuidUtils.test.js
+++ b/__tests__/uuidUtils.test.js
@@ -1,0 +1,26 @@
+const { uuidUtils } = require('../src/utils/uuidUtils');
+
+describe('uuidUtils.decodeUuid', () => {
+  it('decodes a plain 22-char compressed uuid', () => {
+    const out = uuidUtils.decodeUuid('fcmR3XADNLgJ1ByKhqcC5Z');
+    expect(out).toBe('fc991dd7-0033-4b80-9d41-c8a86a702e59');
+  });
+
+  it('decodes base and preserves @subAsset suffix', () => {
+    expect(uuidUtils.decodeUuid('20g1ukYUVPvKWKBRznAKo+@6c48a'))
+      .toBe('20835ba4-6145-4fbc-a58a-051ce700aa3e@6c48a');
+    expect(uuidUtils.decodeUuid('20g1ukYUVPvKWKBRznAKo+@f9941'))
+      .toBe('20835ba4-6145-4fbc-a58a-051ce700aa3e@f9941');
+  });
+
+  it('decodes multi-@ compressed native ids (mip + format)', () => {
+    expect(uuidUtils.decodeUuid('6fAc9/gb9Kfr1dCvwZaWSA@b47c0@40c10'))
+      .toBe('6f01cf7f-81bf-4a7e-bd5d-0afc19696480@b47c0@40c10');
+  });
+
+  it('passes through already-decoded / non-22-char ids', () => {
+    const full = '20835ba4-6145-4fbc-a58a-051ce700aa3e';
+    expect(uuidUtils.decodeUuid(full)).toBe(full);
+    expect(uuidUtils.decodeUuid(`${full}@6c48a`)).toBe(`${full}@6c48a`);
+  });
+});

--- a/src/core/cocos3x/engine3x.js
+++ b/src/core/cocos3x/engine3x.js
@@ -324,8 +324,13 @@ async function unpackBundle({ bundleDir, outputPath, verbose, flavor, key, warni
     recovered: 0,
     missing: 0,
     redirected: 0,
+    nativeFiles: 0,
+    nativeImages: 0,
+    sampleNativePaths: [],
     warnings: [],
   };
+  // Shared across concurrent unpackAsset calls — only push samples under lock-free cap.
+  cfg._nativeStats = result;
 
   // Track which uuids we've already processed so we don't duplicate work when
   // a uuid appears in both `paths` and `scenes` and the catch-all uuids pass.
@@ -419,6 +424,22 @@ async function unpackBundle({ bundleDir, outputPath, verbose, flavor, key, warni
     }
   });
 
+  // 4) Sweep native/ for files whose uuid never appeared in config.uuids
+  //    (or whose decode previously missed). Copy leftovers under _packed.
+  await sweepOrphanNatives(cfg, bundleOut, handled, result);
+
+  if (result.nativeImages === 0) {
+    logger.info(
+      `Bundle "${cfg.name}": no native image bytes recovered `
+      + `(import JSON/cconb descriptors only — common for web-mobile)`,
+    );
+  } else {
+    logger.info(
+      `Bundle "${cfg.name}": ${result.nativeImages} native image(s), `
+      + `${result.nativeFiles} native file(s) total`,
+    );
+  }
+
   // Preserve the original config.json for reference — useful when a user wants
   // to re-pack or debug.
   await copyFile(cfgPath, path.join(bundleOut, 'config.original.json'));
@@ -443,10 +464,12 @@ async function unpackAsset({ cfg, uuid, info, bundleOut, verbose, flavor }) {
   const nativeSrc = nativeExt ? getNativePath(cfg, uuid, nativeExt) : null;
 
   // Choose an output path. Prefer the project path from config.paths — that's
-  // what the editor will see.
+  // what the editor will see. Strip `/texture` / `@6c48a` subAsset segments so
+  // natives never land under a fake `…/texture.png` leaf.
   const className = info.type || 'cc.Asset';
   const outDir = classOutputDir(className);
-  const relPath = normalizeDbAssetPath(info.path) || `${outDir}/${uuid}`;
+  const rawRel = normalizeDbAssetPath(info.path) || `${outDir}/${uuid}`;
+  const relPath = normalizeAssetFilePath(rawRel) || rawRel;
   const outBase = path.join(bundleOut, relPath);
   await mkdir(path.dirname(outBase), { recursive: true });
 
@@ -543,6 +566,18 @@ async function unpackAsset({ cfg, uuid, info, bundleOut, verbose, flavor }) {
     }
   }
 
+  if (nativeRecovered && cfg._nativeStats) {
+    cfg._nativeStats.nativeFiles += 1;
+    const extLower = (recoveredNativeExt || '').toLowerCase();
+    if (['.png', '.jpg', '.jpeg', '.webp', '.pvr', '.pkm', '.astc'].includes(extLower)) {
+      cfg._nativeStats.nativeImages += 1;
+    }
+    const samples = cfg._nativeStats.sampleNativePaths;
+    if (samples.length < 8) {
+      samples.push(relPath + (recoveredNativeExt || ''));
+    }
+  }
+
   // --- Packed asset (extract section from IPackedFileData) ---
   if (!importRecovered && cfg._packIndex && cfg._packIndex[uuid]) {
     const { packUuid, position } = cfg._packIndex[uuid];
@@ -584,21 +619,63 @@ function indexImageSubAssets(cfg) {
   const byParent = new Map();
   const childUuids = new Set();
   const paths = cfg.paths || {};
-  for (const uuid of Object.keys(paths)) {
-    const info = paths[uuid];
-    if (!info || !info.subAsset) continue;
-    const parentPath = parentPathOfSubAsset(info.path);
-    if (!parentPath) continue;
-    const displayName = displayNameOfSubAsset(info.path, info.type);
+
+  const addChild = (parentPath, uuid, type, relPath) => {
+    if (!parentPath || !uuid || childUuids.has(uuid)) return;
+    const displayName = displayNameOfSubAsset(relPath || uuid, type);
     if (!byParent.has(parentPath)) byParent.set(parentPath, []);
     byParent.get(parentPath).push({
       uuid,
-      type: info.type,
-      path: info.path,
+      type: type || null,
+      path: relPath || null,
       displayName,
     });
     childUuids.add(uuid);
+  };
+
+  // 1) Named subAssets from config.paths (Texture2D / SpriteFrame).
+  for (const uuid of Object.keys(paths)) {
+    const info = paths[uuid];
+    if (!info) continue;
+    const parentPath = parentPathOfSubAsset(info.path);
+    // Require a recognizable parent path shape — the release `paths` third
+    // field is often `1` even for ImageAsset/SceneAsset, so don't trust the
+    // flag alone.
+    if (!parentPath) continue;
+    if (!info.subAsset && info.type !== 'cc.Texture2D' && info.type !== 'cc.SpriteFrame') {
+      continue;
+    }
+    addChild(parentPath, uuid, info.type, info.path);
   }
+
+  // 2) UUID-only `@6c48a` / `@f9941` siblings (common in scene bundles where
+  //    the ImageAsset has no addressable path). Fold onto the parent's path
+  //    when known, otherwise onto the same `_packed/<2>/<base>` slot the
+  //    catch-all pass uses for the parent ImageAsset.
+  const uuidSet = new Set(cfg.uuids || []);
+  for (const uuid of cfg.uuids || []) {
+    if (childUuids.has(uuid)) continue;
+    const at = uuid.indexOf('@');
+    if (at <= 0) continue;
+    const suffix = uuid.slice(at + 1);
+    // Skip multi-@ compressed format variants (uuid@mip@astc) — those are
+    // separate native blobs, not ImageAsset subMetas.
+    if (!suffix || suffix.includes('@')) continue;
+    const base = uuid.slice(0, at);
+    if (!uuidSet.has(base) && !paths[base]) continue;
+
+    let parentPath = null;
+    if (paths[base] && paths[base].path) {
+      parentPath = parentPathOfSubAsset(paths[base].path) || paths[base].path;
+    } else {
+      parentPath = `_packed/${base.slice(0, 2)}/${base}`;
+    }
+    const typeHint = /^f9941$/i.test(suffix)
+      ? 'cc.SpriteFrame'
+      : (/^6c48a$/i.test(suffix) ? 'cc.Texture2D' : null);
+    addChild(parentPath, uuid, typeHint, paths[uuid] ? paths[uuid].path : null);
+  }
+
   return { byParent, childUuids };
 }
 
@@ -608,6 +685,21 @@ function parentPathOfSubAsset(relPath) {
   if (at > 0) return relPath.slice(0, at);
   const m = relPath.match(/^(.*)\/(texture|spriteFrame|sprite-frame)$/i);
   return m ? m[1] : null;
+}
+
+/**
+ * Choose the on-disk file path for an asset. Strips Creator ImageAsset subAsset
+ * segments (`/texture`, `/spriteFrame`, `@6c48a`, `@f9941`) so natives never
+ * land at `UI_res/headimage/texture.png`. Does NOT strip mip/format suffixes
+ * like `@b47c0@40c10` — those are distinct native blobs.
+ */
+function normalizeAssetFilePath(relPath) {
+  if (!relPath || typeof relPath !== 'string') return relPath;
+  const slash = relPath.match(/^(.*)\/(texture|spriteFrame|sprite-frame)$/i);
+  if (slash) return slash[1];
+  const atKnown = relPath.match(/^(.*)@(6c48a|f9941)$/i);
+  if (atKnown) return atKnown[1];
+  return relPath;
 }
 
 function displayNameOfSubAsset(relPath, type) {
@@ -623,7 +715,14 @@ function displayNameOfSubAsset(relPath, type) {
 }
 
 function shortMetaId(uuid) {
-  const hex = String(uuid || '').replace(/-/g, '');
+  const s = String(uuid || '');
+  // Creator sub-assets use the @suffix as the meta id (6c48a / f9941). Using the
+  // compressed-base prefix collided Texture2D + SpriteFrame into one slot.
+  const at = s.lastIndexOf('@');
+  if (at >= 0 && at < s.length - 1) {
+    return (s.slice(at + 1) || '00000').toLowerCase();
+  }
+  const hex = s.replace(/-/g, '');
   return (hex.slice(0, 5) || '00000').toLowerCase();
 }
 
@@ -669,6 +768,84 @@ function classOutputDir(className) {
  * Last-resort: scan native/<2>/ for any file whose basename matches `uuid`.
  * Returns { src, ext } or null.
  */
+/**
+ * Copy native files that were never claimed by a uuid in config.uuids.
+ * Filenames look like `<uuid>[@mip][@fmt].<ext>` under native/<2>/.
+ */
+async function sweepOrphanNatives(cfg, bundleOut, handled, result) {
+  const nativeRoot = path.join(cfg.baseDir, cfg.nativeBase);
+  if (!fs.existsSync(nativeRoot)) return;
+
+  let prefixes;
+  try {
+    prefixes = await readdir(nativeRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  // Build a set of uuid stems we already recovered natives for (exact + base).
+  const claimed = new Set();
+  for (const u of handled) {
+    if (!u) continue;
+    claimed.add(u);
+    const at = u.indexOf('@');
+    if (at > 0) claimed.add(u.slice(0, at));
+  }
+
+  for (const pref of prefixes) {
+    if (!pref.isDirectory()) continue;
+    const dir = path.join(nativeRoot, pref.name);
+    let entries;
+    try {
+      entries = await readdir(dir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const m = entry.match(/^([0-9a-fA-F-]{36}(?:@[0-9a-zA-Z]+)*)(\.[^.]+)$/);
+      if (!m) continue;
+      const fileUuid = m[1];
+      const ext = m[2];
+      // Skip if this exact uuid was handled, or its base ImageAsset was handled
+      // and this is a simple @6c48a/@f9941 meta-only id without its own bytes
+      // already claimed via glob on the parent… Still copy distinct @mip@fmt.
+      if (handled.has(fileUuid)) continue;
+      const base = fileUuid.indexOf('@') > 0 ? fileUuid.slice(0, fileUuid.indexOf('@')) : fileUuid;
+      // If the exact file was already copied as the native of `fileUuid` or
+      // `base` (same basename), skip. We detect via output existence.
+      const rel = `_packed/${fileUuid.slice(0, 2)}/${fileUuid}`;
+      const dest = path.join(bundleOut, rel + ext);
+      if (fs.existsSync(dest)) continue;
+      // Also skip when parent ImageAsset already took a same-ext native at its
+      // path and this entry is only `@6c48a`/`@f9941` (no extra mip/format).
+      const suffix = fileUuid.includes('@') ? fileUuid.slice(fileUuid.indexOf('@') + 1) : '';
+      if (suffix && !suffix.includes('@') && /^(6c48a|f9941)$/i.test(suffix)) {
+        continue; // meta-only subAsset ids — no separate native expected
+      }
+      if (claimed.has(fileUuid)) continue;
+
+      const src = path.join(dir, entry);
+      try {
+        await mkdir(path.dirname(dest), { recursive: true });
+        await copyFile(src, dest);
+        result.nativeFiles += 1;
+        const extLower = ext.toLowerCase();
+        if (['.png', '.jpg', '.jpeg', '.webp', '.pvr', '.pkm', '.astc'].includes(extLower)) {
+          result.nativeImages += 1;
+        }
+        if (result.sampleNativePaths.length < 8) {
+          result.sampleNativePaths.push(rel + ext);
+        }
+        // Mark handled so we don't double-count if called twice.
+        handled.add(fileUuid);
+        logger.debug(`Orphan native: ${rel}${ext}`);
+      } catch (err) {
+        logger.debug(`Orphan native skip ${entry}: ${err.message}`);
+      }
+    }
+  }
+}
+
 async function globNativeByUuid(cfg, uuid) {
   const dir = path.join(cfg.baseDir, cfg.nativeBase, uuid.slice(0, 2));
   if (!fs.existsSync(dir)) return null;
@@ -1318,7 +1495,9 @@ module.exports = {
   sanitizeScriptFileName,
   indexImageSubAssets,
   parentPathOfSubAsset,
+  normalizeAssetFilePath,
   buildImageSubMetas,
+  shortMetaId,
   extractRfUuid,
 };
 

--- a/src/utils/recoveryReport.js
+++ b/src/utils/recoveryReport.js
@@ -74,6 +74,27 @@ async function writeRecoveryReport(outputPath, summary, sourcePath) {
           `| ${b.name} | ${b.encrypted ? 'yes' : 'no'} | ${b.uuidCount} | ${b.pathCount} | ${b.recovered} | ${b.missing} |`,
         );
       }
+      lines.push('');
+      lines.push('### Native media');
+      lines.push('');
+      let anyNativeNote = false;
+      for (const b of summary.bundles) {
+        if (b.nativeFiles == null && b.nativeImages == null) continue;
+        anyNativeNote = true;
+        const imgs = b.nativeImages ?? 0;
+        const files = b.nativeFiles ?? 0;
+        lines.push(`- **${b.name}**: ${imgs} image(s), ${files} native file(s)`);
+        if (Array.isArray(b.sampleNativePaths) && b.sampleNativePaths.length) {
+          for (const p of b.sampleNativePaths.slice(0, 5)) {
+            lines.push(`  - \`${p}\``);
+          }
+        } else if (imgs === 0) {
+          lines.push('  - _(no native image bytes — import descriptors only)_');
+        }
+      }
+      if (!anyNativeNote) {
+        lines.push('_Native image stats unavailable._');
+      }
     }
     lines.push('');
   }

--- a/src/utils/uuidUtils.js
+++ b/src/utils/uuidUtils.js
@@ -34,11 +34,16 @@ const uuidUtils = {
   },
 
   /**
-   * 将 Base64 编码的 UUID 转换为标准 UUID 格式
-   * 示例: fcmR3XADNLgJ1ByKhqcC5Z -> fc991dd7-0033-4b80-9d41-c8a86a702e59
+   * Decode a Creator compressed uuid. Handles plain 22-char ids and the
+   * common `@subAsset` / `@mip@format` suffixes used by Texture2D / SpriteFrame
+   * / compressed natives, e.g.:
+   *   20g1ukYUVPvKWKBRznAKo+@6c48a
+   *     -> 20835ba4-6145-4fbc-a58a-051ce700aa3e@6c48a
+   *   6fAc9/gb9Kfr1dCvwZaWSA@b47c0@40c10
+   *     -> 6f01cf7f-81bf-4a7e-bd5d-0afc19696480@b47c0@40c10
    *
-   * @param {string} base64 Base64 编码的 UUID
-   * @returns {string} 标准格式的 UUID
+   * Without this, native/<2>/<decodedUuid>@….png lookups miss because the
+   * uuid table keeps the still-compressed base.
    */
   decodeUuid(base64) {
     if (typeof base64 !== 'string') {
@@ -46,26 +51,35 @@ const uuidUtils = {
       return undefined;
     }
 
-    if (base64.length !== 22) {
+    // Preserve @suffix(es); only the 22-char head is base64-compressed.
+    let suffix = '';
+    let head = base64;
+    const at = base64.indexOf('@');
+    if (at >= 0) {
+      head = base64.slice(0, at);
+      suffix = base64.slice(at); // includes leading '@'
+    }
+
+    if (head.length !== 22) {
       return base64;
     }
 
     try {
       // 每次拷贝模板，避免共享可变数组被并发写坏
       const template = UuidTemplate.slice();
-      template[0] = base64[0];
-      template[1] = base64[1];
+      template[0] = head[0];
+      template[1] = head[1];
 
       for (let i = 2, j = 2; i < 22; i += 2) {
-        const lhs = BASE64_VALUES[base64.charCodeAt(i)];
-        const rhs = BASE64_VALUES[base64.charCodeAt(i + 1)];
+        const lhs = BASE64_VALUES[head.charCodeAt(i)];
+        const rhs = BASE64_VALUES[head.charCodeAt(i + 1)];
 
         template[Indices[j++]] = HexChars[lhs >> 2];
         template[Indices[j++]] = HexChars[((lhs & 3) << 2) | (rhs >> 4)];
         template[Indices[j++]] = HexChars[rhs & 0xF];
       }
 
-      return template.join('');
+      return template.join('') + suffix;
     } catch (err) {
       logger.error('解码 UUID 时出错:', err);
       return base64;


### PR DESCRIPTION
Decode Creator @-suffix uuids so native texture lookups and ImageAsset subMetas work. See branch commit for details. Tests: 156 green. Validated on MeiXiaoan/playable/flappy.