### PR TITLE
fix: strip leading assets after db path normalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Strip `/texture` / `/spriteFrame` / `@6c48a|@f9941` from output file paths; fold uuid-only `@` siblings onto parent ImageAsset (named path or `_packed/<2>/<base>`)
 - Sweep leftover `native/` files and report per-bundle native image counts (explicit “import descriptors only” note for web-mobile builds with zero image bytes)
 - Normalize `config.paths` `db://` **and** `db:/` (single-slash) prefixes so recovered assets are not written under a literal `db:` directory (real Creator 3.8 web-mobile)
+- Strip leading `assets/` after `db://`/`db:/` normalize so bundle output is `assets/<bundle>/scenes/...` not `assets/<bundle>/assets/scenes/...` (keeps `internal/...` and plain `UI_res/...` paths)
 - Treat Creator 3.x rollup `System.register("chunks:///_virtual/...")` packs as SystemJS (not browserify); demux one file per register id (`Foo.ts`) with aliased `._RF.push` UUID metas — no more bogus `setters.ts`
 - Skip anonymous / variable-id `System.register` wrappers (nested rollup shell + `mid`/`cid` reexports) so recovery no longer emits empty `module_N.js` stubs
 - **Issue #33**: Write meta as `basename+ext+.meta` (e.g. `logo.png.meta`); do not emit orphan `.png.meta` when native PNG was not recovered (2.x SpriteFrame + 3.x pure-native)

--- a/__tests__/cocos3x/bundleConfig.test.js
+++ b/__tests__/cocos3x/bundleConfig.test.js
@@ -160,17 +160,24 @@ describe('findBundleConfigPath / hasBundleConfig (MD5 Cache)', () => {
 });
 
 describe('normalizeDbAssetPath', () => {
-  it('strips db:// and db:/ (single-slash) prefixes', () => {
-    expect(normalizeDbAssetPath('db://assets/scene/scene')).toBe('assets/scene/scene');
-    expect(normalizeDbAssetPath('db:/assets/scene/scene')).toBe('assets/scene/scene');
+  it('strips db:// / db:/ and leading assets/ (no double assets under bundle)', () => {
+    expect(normalizeDbAssetPath('db://assets/scenes/foo')).toBe('scenes/foo');
+    expect(normalizeDbAssetPath('db:/assets/scenes/foo')).toBe('scenes/foo');
+    expect(normalizeDbAssetPath('db://assets/scene/scene')).toBe('scene/scene');
+    expect(normalizeDbAssetPath('db:/assets/scene/scene')).toBe('scene/scene');
     expect(normalizeDbAssetPath('db:/internal/physics/default-physics-material')).toBe(
       'internal/physics/default-physics-material',
     );
   });
 
-  it('leaves plain relative paths alone', () => {
+  it('leaves plain relative paths alone (no assets/ prefix)', () => {
     expect(normalizeDbAssetPath('scenes/Main')).toBe('scenes/Main');
     expect(normalizeDbAssetPath('textures/logo')).toBe('textures/logo');
+    expect(normalizeDbAssetPath('UI_res/headimage/texture')).toBe('UI_res/headimage/texture');
+  });
+
+  it('strips bare leading assets/ even without db: prefix', () => {
+    expect(normalizeDbAssetPath('assets/textures/logo')).toBe('textures/logo');
   });
 
   it('passes through nullish', () => {
@@ -180,22 +187,25 @@ describe('normalizeDbAssetPath', () => {
 });
 
 describe('parseBundleConfig — real 3.8 db:/ paths', () => {
-  it('normalizes db:/assets/... path entries (no literal db: segment)', () => {
+  it('normalizes db:/assets/... without double assets or literal db: segment', () => {
     const raw = {
       name: 'main',
       debug: true,
-      uuids: ['u-scene', 'u-mat'],
+      uuids: ['u-scene', 'u-mat', 'u-tex'],
       paths: {
         0: ['db:/assets/scene/scene', 0],
         1: ['db:/internal/physics/default-physics-material', 1],
+        2: ['UI_res/headimage/texture', 2],
       },
-      types: ['cc.SceneAsset', 'cc.PhysicsMaterial'],
+      types: ['cc.SceneAsset', 'cc.PhysicsMaterial', 'cc.Texture2D'],
       scenes: { 'db://assets/scene/scene.scene': '0' },
     };
     const cfg = parseBundleConfig(raw, '/fake/main');
-    expect(cfg.paths['u-scene'].path).toBe('assets/scene/scene');
+    expect(cfg.paths['u-scene'].path).toBe('scene/scene');
     expect(cfg.paths['u-mat'].path).toBe('internal/physics/default-physics-material');
+    expect(cfg.paths['u-tex'].path).toBe('UI_res/headimage/texture');
     expect(cfg.paths['u-scene'].path.includes('db:')).toBe(false);
+    expect(cfg.paths['u-scene'].path.startsWith('assets/')).toBe(false);
   });
 });
 

--- a/__tests__/cocos3x/engine3x.test.js
+++ b/__tests__/cocos3x/engine3x.test.js
@@ -559,9 +559,10 @@ System.register("chunks:///_virtual/Enemy.ts", ["cc"], function (e) {
     const out = path.join(tmp, 'out-dbslash');
     await reverseProject3x({ sourcePath: src, outputPath: out, assetsOnly: true });
 
-    const goodA = path.join(out, 'assets', 'main', 'assets', 'scene', 'scene.scene');
-    const goodB = path.join(out, 'assets', 'main', 'scene', 'scene.scene');
-    expect(fs.existsSync(goodA) || fs.existsSync(goodB)).toBe(true);
+    const doubleAssets = path.join(out, 'assets', 'main', 'assets', 'scene', 'scene.scene');
+    const good = path.join(out, 'assets', 'main', 'scene', 'scene.scene');
+    expect(fs.existsSync(good)).toBe(true);
+    expect(fs.existsSync(doubleAssets)).toBe(false);
     expect(fs.existsSync(path.join(out, 'assets', 'main', 'db:'))).toBe(false);
     // No path segment literally named db:
     const walk = (dir, acc = []) => {

--- a/src/core/cocos3x/bundleConfig.js
+++ b/src/core/cocos3x/bundleConfig.js
@@ -16,14 +16,21 @@ const { uuidUtils } = require('../../utils/uuidUtils');
  * output paths stay project-relative (never a literal `db:` directory).
  * Real 3.8 web-mobile builds often use ONE slash: `db:/assets/scene/scene`.
  *
+ * Also drops a leading `assets/` segment: bundle recovery writes under
+ * `assets/<bundleName>/`, so keeping `assets/` would produce the double
+ * prefix `assets/main/assets/scenes/...`. Paths that are already bundle-
+ * relative (`UI_res/...`, `textures/...`) and `internal/...` are unchanged.
+ *
  * @param {string|null|undefined} relPath
  * @returns {string|null|undefined}
  */
 function normalizeDbAssetPath(relPath) {
   if (relPath == null || typeof relPath !== 'string') return relPath;
   let s = relPath.replace(/^db:\/+/i, '');
-  // Drop leading ./ noise only — keep a leading `assets/` segment when present.
+  // Drop leading ./ noise.
   s = s.replace(/^(?:\.\/)+/, '');
+  // Avoid assets/<bundle>/assets/... when db path was db://assets/...
+  s = s.replace(/^assets\//i, '');
   return s;
 }
 


### PR DESCRIPTION
Strip leading assets/ after db:/ normalize so bundle output has no double assets prefix. Tests 163 green. Sample paths validated.